### PR TITLE
Fix issue 'TypeError: msecs must be a number for timeout socket'

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "formidable": "1.0.14",
     "connect": "2.4.x",
-    "emailjs": "0.3.4",
+    "emailjs": "0.3.12",
     "crypto": "0.0.3",
     "nodemailer": "0.5.2",
     "mysql": "2.0.0-alpha9",


### PR DESCRIPTION
I fix this error by updating email.js to version 0.3.12.
I find the solution at this url : https://github.com/wavded/winston-mail/issues/16.
Because I "love" ;) understand error, I study the problem in more depth. The problem was at the end of response.js file. The declaration of exports.monitor was wrong. It missed two parameters : timeout (our problem) and onerror function.
I test with my case (SMTP with SSL to Gmail) and it works now. 